### PR TITLE
リージョンの修正

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -10,7 +10,7 @@ amazon:
   service: S3
   access_key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
   secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
-  region: ap-northeast-1
+  region: ap-southeast-1
   bucket: <%= ENV['AWS_BUCKET_NAME'] %>
 
 # Use bin/rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)


### PR DESCRIPTION
### 概要
設定していたリージョンが参考資料のものになっていたので、失敗したバケットのリージョンに統一