### PR TITLE
profileの詳細・削除・編集機能の追加

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,0 +1,37 @@
+class ProfilesController < ApplicationController
+  before_action :set_user, only: %i[edit update destroy]
+
+  def edit; end
+
+  def update
+    if @user.update(user_params)
+      flash[:notice] = t("flash.updated", item: User.model_name.human)
+      redirect_to profile_path
+    else
+      flash.now[:alert] = t("flash.not_updated", item: User.model_name.human)
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def show; end
+
+  def destroy
+    if @user.destroy
+      flash[:notice] = t("flash.deleted", item: User.model_name.human)
+      redirect_to root_path
+    else
+      flash[:alert] = t("flash.not_deleted", item: User.model_name.human)
+      redirect_to profile_path
+    end
+  end
+
+  private
+
+  def set_user
+    @user = current_user
+  end
+
+  def user_params
+    params.require(:user).permit(:name) # `name` のみ編集対象
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,6 +8,7 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
+      auto_login(@user)
       flash[:notice] = t("flash.users.create.success")
       redirect_to root_path
     else

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,7 +19,7 @@
     <script src="https://cdn.jsdelivr.net/npm/swiper@8/swiper-bundle.min.js"></script>
   </head>
 
-  <body class="bg-gray-100">
+  <body class="bg-gray-100 min-h-screen">
     <% if logged_in? %>
       <%= render 'shared/header' %>
     <% else %>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,4 +1,4 @@
-<div class="w-full lg:w-[calc(25%-1rem)] mb-3 lg:mr-3 bg-white p-4 rounded-lg shadow-md flex relative flex-col">
+<div class="w-full lg:w-[calc(25%-1rem)] mb-3 mx-2 lg:mr-3 bg-white p-4 rounded-lg shadow-md flex relative flex-col">
   <!-- タイトル（背景色：緑） -->
   <h4 class="card-title text-lg font-semibold bg-green-500 text-white p-2 rounded-md mb-2">
     <%= link_to truncate(post.title, length: 19), post_path(post) %> <!-- 投稿の詳細ページへのリンク -->

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,0 +1,13 @@
+<div class="container mx-auto p-4">
+  <div class="max-w-md mx-auto bg-white shadow-lg rounded-lg p-6">
+    <h1 class="text-2xl font-bold mb-4 text-center"><%= t('.title') %></h1>
+    <%= form_with model: @user, url: profile_path, method: :patch do |f| %>
+      <%= render 'shared/error_messages', object: f.object %>
+      <div class="mb-4">
+        <%= f.label :name, class: "block text-sm font-medium text-gray-700" %>
+        <%= f.text_field :name, class: "mt-1 block w-full border border-gray-300 rounded-md shadow-sm focus:border-blue-500 focus:ring-blue-500" %>
+      </div>
+      <%= f.submit class: "w-full py-2 px-4 bg-blue-500 text-white font-semibold rounded-md hover:bg-blue-600" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,0 +1,30 @@
+<div class="max-w-3xl mx-auto bg-white p-6 shadow rounded-lg my-3 mx-2 flex flex-col justify-center">
+  <h1 class="text-2xl font-bold mb-4 text-center">プロフィール詳細</h1>
+
+  <div class="mb-2">
+    <p>
+      <span class="font-semibold">名前:</span> <%= current_user.name %>
+    </p>
+    <p>
+      <span class="font-semibold">投稿数:</span> <%= current_user.posts.count %>
+    </p>
+  </div>
+
+  <div class="flex justify-end">
+    <!-- 編集ボタン -->
+    <%= link_to edit_profile_path, id: "button-edit-profile", class: "flex items-center text-blue-500 hover:bg-gray-100 rounded px-2 py-2" do %>
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-blue-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+        <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" />
+      </svg>
+    <% end %>
+
+    <!-- 削除ボタン -->
+    <%= link_to profile_path, id: "button-delete-profile", 
+          data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" },
+          class: "flex items-center text-red-500 hover:bg-gray-100 rounded px-2 py-2" do %>
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-red-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+      </svg>
+    <% end %>
+  </div>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -33,6 +33,9 @@
           <!-- ログアウト -->
           <ul class="absolute left-0 mt-2 min-w-max bg-white rounded shadow-lg hidden peer-checked:block z-50">
             <li>
+              <%= link_to t('header.profile'), profile_path, class: "block px-4 py-2 text-gray-700 hover:bg-gray-100" %>
+            </li>
+            <li>
               <%= link_to t('header.logout'), logout_path, data: { turbo_method: :delete }, class: "block px-4 py-2 text-gray-700 hover:bg-gray-100" %>
             </li>
           </ul>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -25,10 +25,16 @@ ja:
       title: 記録詳細画面
     edit:
       title: 記録編集画面
+  profiles:
+    show:
+      title: プロフィール詳細画面
+    edit:
+      title: プロフィール編集画面
   header:
     login: ログイン
     logout: ログアウト
     signup: 新規登録
+    profile: プロフィール
   flash:
     created: "%{item}を作成しました"
     not_created: "%{item}を作成出来ませんでした"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   get "login", to: "user_sessions#new"
   post "login", to: "user_sessions#create"
   delete "logout", to: "user_sessions#destroy"
+  resource :profile, only: %i[show edit update destroy]
 
   root "posts#index"
 


### PR DESCRIPTION
## 概要
プロフィールの詳細・編集・削除機能の追加

### 主な内容
- プロフィールコントローラの作成
- current_userを利用したユーザーの詳細・編集ページの追加
- ユーザーの削除機能の追加

### 補足
- モデルを持たないコントローラを作成してのプロフィールページの作成を行いました。理由としては、ログインしていないユーザーが容易に操作できないようにするため
- ルーティングにはresouseを使用してidの必要ないページの作成
